### PR TITLE
Fix anchor link typo in 1.concepts/1.messages.md

### DIFF
--- a/doc/content/3.documentation/1.concepts/1.messages.md
+++ b/doc/content/3.documentation/1.concepts/1.messages.md
@@ -54,7 +54,7 @@ namespace Company.Application.Contracts
 }
 ```
 
-When defining a message type using an interface, MassTransit will create a dynamic class implementing the interface for serialization, allowing the interface with get-only properties to be presented to the consumer. To create an interface message, use a [message initializer](/documentation/concepts/producers##message-initialization).
+When defining a message type using an interface, MassTransit will create a dynamic class implementing the interface for serialization, allowing the interface with get-only properties to be presented to the consumer. To create an interface message, use a [message initializer](/documentation/concepts/producers#message-initialization).
 
 ### Classes
 


### PR DESCRIPTION
- An anchor link had a double hash symbol leading to a disconnect in reading when clicking the link, since the user doesn't land on the intended spot on the page.

